### PR TITLE
Doing left swipe actions?

### DIFF
--- a/Sources/SwipeActions/SwipeActions.swift
+++ b/Sources/SwipeActions/SwipeActions.swift
@@ -366,13 +366,13 @@ public struct SwipeActionGroup {
     public let allActions: [SwipeAction]
     public let continuationBehavior: SwipeContinuationBehavior
     
-    init(mainAction: SwipeAction, otherActions: [SwipeAction] = [], continuationBehavior: SwipeContinuationBehavior = .stop) {
+    public init(mainAction: SwipeAction, otherActions: [SwipeAction] = [], continuationBehavior: SwipeContinuationBehavior = .stop) {
         self.mainAction = mainAction
         self.allActions = [mainAction] + otherActions
         self.continuationBehavior = continuationBehavior
     }
     
-    init(deleteAction: SwipeAction, otherActions: [SwipeAction] = []) {
+    public init(deleteAction: SwipeAction, otherActions: [SwipeAction] = []) {
         self.init(mainAction: deleteAction, otherActions: otherActions, continuationBehavior: .delete)
     }
     


### PR DESCRIPTION
In order to do a left swipe action, it looks like `addSwipeActions(leftActions: SwipeActionGroup ...)` needs to be called. But `SwipeActionGroup` has no publicly scoped inits. So I added public to the inits in that struct.

But is there a different intended way for users to setup left swipes?